### PR TITLE
Add a fix for Action unable to run pytest

### DIFF
--- a/.github/workflows/update_readme.yml
+++ b/.github/workflows/update_readme.yml
@@ -32,11 +32,11 @@ jobs:
       - name: Run pytest
         working-directory: ${{ env.work-dir }}
         run: |
-          pipenv run pytest
+          pipenv run python -m pytest
       - name: Update README
         working-directory: ${{ env.work-dir }}
         run: |-
-          python build_readme.py
+          pipenv python update_readme.py
           cat ../README.md
       - name: Commit and push if changed
         run: |-

--- a/update_readme/templates/README.md.jinja
+++ b/update_readme/templates/README.md.jinja
@@ -16,3 +16,4 @@ Here are some ideas to get you started:
 -->
 
 Last updated: {{ last_updated }}
+


### PR DESCRIPTION
This is the error for reference:
```
Successfully created virtual environment!
Virtualenv location: /home/runner/.local/share/virtualenvs/update_readme-MseaZi-e
Error: the command pytest could not be found within PATH or Pipfile's [scripts].
Error: Process completed with exit code 1.
```


Also add a newline that was missing in the `README.md` jinja template.