### PR TITLE
Move the conference sorting to the jinja template

### DIFF
--- a/update_readme/templates/README.md.jinja
+++ b/update_readme/templates/README.md.jinja
@@ -25,7 +25,7 @@ Here are some ideas to get you started:
 <details><summary>(...)</summary>
 <p>
 <ul>
-{% for item in conf_new %}
+{% for item in conf_new|sort(attribute="end", reverse=True) %}
   {% if item.start %}
 <li><a href="{{item.website}}">{{item.conference}}</a> {{ item.start.strftime("%d") }}-{{ item.end.strftime("%d %B") }}, {{item.end.strftime("%Y")}}{% if item.online %} (Online){% endif -%}</li>
   {% else %}
@@ -40,7 +40,7 @@ Here are some ideas to get you started:
 <details><summary>(...)</summary>
 <p>
 <ul>
-{% for item in conf_old %}
+{% for item in conf_old|sort(attribute="end", reverse=True) %}
   {% if item.start %}
 <li><a href="{{item.website}}">{{item.conference}}</a> {{ item.start.strftime("%d") }}-{{ item.end.strftime("%d %B") }}, {{item.end.strftime("%Y")}}{% if item.online %} (Online){% endif -%}</li>
   {% else %}

--- a/update_readme/update_readme.py
+++ b/update_readme/update_readme.py
@@ -29,7 +29,7 @@ def build_conf_list(csv_file=FILENAME_CSV, year=None):
         for k in ["online", "fee", "registered", "attended"]:
             conf[k] = True if conf[k].lower() == "true" else False
         # replace str with a proper datetime.date object,
-        # if it's a one day conference set start date to None
+        # if it's a one-day conference set start date to None
         conf["start"] = (
             None
             if conf["start"] == conf["end"]
@@ -38,9 +38,6 @@ def build_conf_list(csv_file=FILENAME_CSV, year=None):
         conf["end"] = dt.strptime(conf["end"], "%d/%m/%Y").date()
         # add a key/value with the n of days, set to 1 for one-day conferences
         conf["days"] = (conf["end"] - conf["start"]).days + 1 if conf["start"] else 1
-
-    # now we can order the conferences, for example by end date
-    all_conferences.sort(key=lambda x: x["end"])
 
     # decide what to return based on if the arg `year` was provided
     if year:


### PR DESCRIPTION
It looks like when lists are passed to `jinja2Template.render()` the sorting is lost.

With thisPR the `sorting` is moved to the jinja template.