### PR TITLE
Update workflows to Python 3.10

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -11,14 +11,14 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.9
+    - name: Set up Python 3.10
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: '3.10'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install black==20.8b1
+        pip install black==22.3.0
     - name: Run black
       run: |
         black --version

--- a/.github/workflows/update_readme.yml
+++ b/.github/workflows/update_readme.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: '3.10'
       - name: Install dependencies
         working-directory: ${{ env.work-dir }}
         run: |


### PR DESCRIPTION
Update the workflows to use Python `3.10`.
Update `black` version.